### PR TITLE
restore qunit-plugin keyword in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "frontend",
     "backend",
     "qunit",
+    "qunit-plugin",
     "node",
     "deno",
     "browser"


### PR DESCRIPTION
Originally added in be049d8066 in 2022, and removed a year later in ae698eabd0.

Ref https://github.com/izelnakri/qunitx/pull/37.
Ref https://github.com/qunitjs/qunitjs.com/pull/183.