### PR TITLE
ci: run npm ci before setup-deno in the lint and coverage jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
         with:
           node-version: 24
           cache: npm
+      # Must precede setup-deno — see the note in the test job below.
+      - run: npm ci
       - uses: denoland/setup-deno@v2
         with:
           deno-version: v2.x
@@ -32,7 +34,6 @@ jobs:
           # so the lint job on main populates the cache the rest of them restore from.
           # A corrupt entry surfaces as a failed pre-upload check, never as a bad publish.
           cache: true
-      - run: npm ci
       - run: npm run format
       - run: npm run lint
       - run: npm run lint:docs
@@ -73,6 +74,13 @@ jobs:
       # If deno is in PATH, it rewrites node_modules/ layout via .deno/ store and the
       # NixOS-built SEA binaries end up there. Run npm ci before setup-deno so the
       # postinstall silently skips (deno not found) and npm owns node_modules/.
+      #
+      # This ordering is required in EVERY job that runs npm ci, not just this one.
+      # npm runs package postinstalls concurrently, so with deno in PATH the rewrite
+      # races esbuild's own postinstall — esbuild validates node_modules/esbuild/bin/esbuild
+      # while deno is moving it, and npm ci dies with MODULE_NOT_FOUND. Intermittent by
+      # nature: it took down the coverage job on 2026-08-14 while lint passed in the
+      # same run, both being equally exposed.
       - run: npm ci
       - uses: denoland/setup-deno@v2
         with:
@@ -125,16 +133,17 @@ jobs:
         with:
           node-version: 24
           cache: npm
-      - uses: denoland/setup-deno@v2
-        with:
-          deno-version: v2.x
-          cache: true
       - uses: actions/cache@v6
         with:
           path: dist
           key: dist-${{ hashFiles('shims/**', 'tsconfig.json', 'deno.lock', 'package-lock.json', 'build.ts') }}
           restore-keys: dist-
+      # Must precede setup-deno — see the note in the test job above.
       - run: npm ci
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+          cache: true
       - run: npm run coverage
       - uses: codecov/codecov-action@v7
         with:


### PR DESCRIPTION
Fixes the CI failure on `main` in [run 31763292372](https://github.com/izelnakri/qunitx/actions/runs/31763292372).

## What failed

Not the tests — `test` passed on all three OSes, and `lint` and `bench` passed too. The **`coverage`** job died in `npm ci`, before it ran a single test:

```
npm error path /home/runner/work/qunitx/qunitx/node_modules/esbuild
npm error command sh -c node install.js
npm error Error: Command failed: node .../node_modules/esbuild/bin/esbuild --version
npm error Error: Cannot find module '/home/runner/work/qunitx/qunitx/node_modules/esbuild/bin/esbuild'
npm error   code: 'MODULE_NOT_FOUND'
```

## Why

`qunitx-cli`'s postinstall is:

```
PLAYWRIGHT_SKIP_DOWNLOAD=true deno install --allow-scripts=npm:playwright-core || true
```

When deno is on PATH, that rewrites `node_modules` into deno's `.deno/` store layout. The `test` job already guards against this and documents it:

```yaml
# Run npm ci before setup-deno so the postinstall silently skips (deno not found)
# and npm owns node_modules/.
- run: npm ci
- uses: denoland/setup-deno@v2
```

`lint` and `coverage` had drifted from that ordering — both ran `setup-deno` first, so their `npm ci` executed with deno available.

npm runs package postinstalls **concurrently**, so the rewrite races esbuild's own postinstall: esbuild shells out to `node_modules/esbuild/bin/esbuild --version` to validate its binary while deno is moving that file out from under it. That race is why this is intermittent rather than a clean break — `coverage` lost it while `lint` passed in the very same run, both equally exposed.

## Verification

Reproduced the mechanism locally against a fresh clone:

| `npm ci` with… | `node_modules/.deno` | `node_modules/esbuild/bin/` |
| --- | --- | --- |
| deno on PATH | **present** — deno rewrote the tree | survived that run (won the race) |
| deno removed from PATH, node untouched | absent — npm owns the tree | present |

The reorder removes the rewrite entirely, so there is nothing left to race.

## Change

Moved `npm ci` ahead of `denoland/setup-deno@v2` in `lint` and `coverage`. Every job that runs `npm ci` now does so before setup-deno:

| Job | Before | After |
| --- | --- | --- |
| `lint` | setup-deno → npm ci | npm ci → setup-deno |
| `test` | already correct | unchanged |
| `coverage` | setup-deno → npm ci | npm ci → setup-deno |
| `release-consumer-test` | already correct | unchanged |

`bench` and `publish-jsr` run no `npm ci`, so they are unaffected. All deno-dependent steps still run after setup-deno, and `build.ts` shells out to deno nowhere, so `npm ci`'s `prepare` build is fine without it.

Also expanded the `test` job's note to say the ordering is required in every job, since two had already drifted from it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)